### PR TITLE
Added nv_math files to bk3dlib.

### DIFF
--- a/bk3dlib/CMakeLists.txt
+++ b/bk3dlib/CMakeLists.txt
@@ -27,6 +27,10 @@ set(SOURCES
   ${CPPFILESLEGACY}
   ${CPPFILES}
 )
+source_group(nv_math FILES
+  ${NV_MATH_SOURCE}
+  ${NV_MATH_HEADERS}
+)
 source_group(sources FILES ${SOURCES})
 source_group("" FILES ${PUBLIC_HEADERS})
 
@@ -35,6 +39,8 @@ add_library(bk3dlib STATIC
   ${PUBLIC_HEADERS}
   ${HEADERS}
   ${SOURCES}
+  ${NV_MATH_SOURCE}
+  ${NV_MATH_HEADERS}
 )
 
 set_target_properties( bk3dlib PROPERTIES FOLDER "bk3dlib" )


### PR DESCRIPTION
If the nv_math files are not compiled in the bk3dlib, bk3dlib will fail to
link.
